### PR TITLE
Update Connection class to get kernel-selected bound interface.

### DIFF
--- a/KDIS/KDIS/Network/Connection.cpp
+++ b/KDIS/KDIS/Network/Connection.cpp
@@ -101,7 +101,8 @@ void Connection::bindSocket()
     // been shut down, and then restarted right away.
     KINT32 yes = 1;
     KINT32 iRet = setsockopt( m_iSocket[RECEIVE_SOCK], SOL_SOCKET, SO_REUSEADDR, ( const char * )&yes, sizeof( yes ) );
-    if ( iRet == SOCKET_ERROR ) {
+    if ( iRet == SOCKET_ERROR )
+    {
         THROW_ERROR;
     }
 


### PR DESCRIPTION
I restored the original formatting that I inadvertently changed in a prior update, (though I still managed one minor formatting convention foul-up this time too).

More importantly, you can now retrieve the IP address of the bound interface, regardless of whether it was deliberately set, or automatically chosen by the kernel.

Sorry this took a bit longer than anticipated.  The ability to change the SendTo address *after* binding the socket made it more complex than initially estimated.  Tested in Linux and Windows.