### PR TITLE
chore(cmake): include CPM only if building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,12 @@ endif()
 #
 # Includes
 #
-include(CPM)
 include(GNUInstallDirs)
 include(GenerateExportHeader)
 include(CMakePackageConfigHelpers)
+if(${KDIS_BUILD_TESTS})
+  include(CPM)
+endif()
 
 #
 # Configuration file


### PR DESCRIPTION
Fix #17