### PR TITLE
Include files are installed in the same folder structure as in the source folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -943,7 +943,12 @@ write_basic_package_version_file(
 #
 # Install
 #
-install(FILES ${KDIS_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+foreach(file ${KDIS_HEADERS})
+  get_filename_component(dir ${file} DIRECTORY)
+  string(REPLACE ${KDIS_HEADERS_DIR} "" rel_dir ${dir})
+  install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${rel_dir})
+endforeach()
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}


### PR DESCRIPTION
Currently, when installing the built files using `make && sudo make install` all the include files are installed in the same base directory, for example: `/usr/local/include/KDIS`.

When attempting to build a separate application that links to kdis and uses the installed files, the application is unable to build as the header files cannot be found in the locations specified in the `#include` instructions.

For example, `KDefines.hpp` depends on `KDIS/util/format.hpp`, but `format.hpp` cannot be found in `util` as the `util` folder does not exist (`format.hpp` and all other header files are installed in the same `KDIS/` folder).

This pull request ensures that all the header files are installed using the same folder structure that is used in the source directory. In the example above, `KDIS/util/format.hpp` is installed in `KDIS/util/` and the include files can be found during the build process.