### PR TITLE
fix: add member assignment in GroupDestinationRecord::SetGroupBitField()...

### DIFF
--- a/src/DataTypes/GroupDestinationRecord.cpp
+++ b/src/DataTypes/GroupDestinationRecord.cpp
@@ -80,10 +80,9 @@ void GroupDestinationRecord::SetGroupBitField(KUINT8 Group,
                                               KBOOL InGroup /*= true*/) {
   if (Group > 31) throw KException(ErrorCode::OUT_OF_BOUNDS, __FUNCTION__);
 
-  bitset<32> bits(
-      (KINT32)m_ui32GrpBtField);  // We need to cast to a signed int, this is a
-                                  // visual studio 2010 fix
+  std::bitset<32> bits(m_ui32GrpBtField);
   InGroup ? bits.set(Group) : bits.reset(Group);
+  m_ui32GrpBtField = static_cast<KUINT32>(bits.to_ulong());
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -91,9 +90,7 @@ void GroupDestinationRecord::SetGroupBitField(KUINT8 Group,
 KBOOL GroupDestinationRecord::IsGroupBitSet(KUINT8 Group) const {
   if (Group > 31) throw KException(ErrorCode::OUT_OF_BOUNDS, __FUNCTION__);
 
-  const bitset<32> bits(
-      (KINT32)m_ui32GrpBtField);  // We need to cast to a signed int, this is a
-                                  // visual studio 2010 fix
+  const std::bitset<32> bits(m_ui32GrpBtField);
   return bits.test(Group);
 }
 

--- a/tests/DataType_EncodeDecode6.cpp
+++ b/tests/DataType_EncodeDecode6.cpp
@@ -363,6 +363,20 @@ TEST(DataType_EncodeDecode6, GroupAssignmentRecord) {
 
 TEST(DataType_EncodeDecode6, GroupDestinationRecord) {
   KDIS::DATA_TYPE::GroupDestinationRecord dtIn;
+  for (KDIS::KUINT8 ii = 0; ii < 32; ++ii) {
+    EXPECT_NO_THROW(dtIn.SetGroupBitField(ii, false));
+  }
+  EXPECT_EQ(false, dtIn.IsGroupBitSet(0));
+  EXPECT_EQ(false, dtIn.IsGroupBitSet(13));
+  EXPECT_EQ(false, dtIn.IsGroupBitSet(31));
+  EXPECT_THROW(dtIn.IsGroupBitSet(32), KDIS::KException);
+  EXPECT_THROW(dtIn.SetGroupBitField(32, true), KDIS::KException);
+  for (KDIS::KUINT8 ii = 0; ii < 32; ++ii) {
+    EXPECT_NO_THROW(dtIn.SetGroupBitField(ii, true));
+  }
+  EXPECT_TRUE(dtIn.IsGroupBitSet(0));
+  EXPECT_TRUE(dtIn.IsGroupBitSet(22));
+  EXPECT_TRUE(dtIn.IsGroupBitSet(31));
   KDIS::KDataStream stream = dtIn.Encode();
   KDIS::DATA_TYPE::GroupDestinationRecord dtOut(stream);
   EXPECT_EQ(dtIn, dtOut);


### PR DESCRIPTION
- Also remove C-style casts to KINT32 in both GroupDestinationRecord::SetGroupBitField() and GroupDestinationRecord::IsGroupBitSet(). No evidence was given for the commented reason for these casts, and no related unit test exists.

- Also add unit testing to support this overall change.