### PR TITLE
chore: renamed LifeFormAppearance::Set/GetEntityEntityCompliance()

### DIFF
--- a/include/KDIS/DataTypes/LifeFormAppearance.hpp
+++ b/include/KDIS/DataTypes/LifeFormAppearance.hpp
@@ -94,13 +94,13 @@ struct KDIS_EXPORT LifeFormAppearance {
   KDIS::DATA_TYPE::ENUMS::EntityDamage GetEntityDamage() const;
 
   //************************************
-  // FullName:    KDIS::DATA_TYPE::LifeFormAppearance::SetEntityEntityCompliance
-  //              KDIS::DATA_TYPE::LifeFormAppearance::GetEntityEntityCompliance
+  // FullName:    KDIS::DATA_TYPE::LifeFormAppearance::SetEntityCompliance
+  //              KDIS::DATA_TYPE::LifeFormAppearance::GetEntityCompliance
   // Description: Describes compliance of life form.
   // Parameter:   EntityCompliance EC
   //************************************
-  void SetEntityEntityCompliance(KDIS::DATA_TYPE::ENUMS::EntityCompliance EC);
-  KDIS::DATA_TYPE::ENUMS::EntityCompliance GetEntityEntityCompliance() const;
+  void SetEntityCompliance(KDIS::DATA_TYPE::ENUMS::EntityCompliance EC);
+  KDIS::DATA_TYPE::ENUMS::EntityCompliance GetEntityCompliance() const;
 
   //************************************
   // FullName:    KDIS::DATA_TYPE::LifeFormAppearance::SetEntitySignalSmokeInUse

--- a/src/DataTypes/LifeFormAppearance.cpp
+++ b/src/DataTypes/LifeFormAppearance.cpp
@@ -59,13 +59,13 @@ EntityDamage LifeFormAppearance::GetEntityDamage() const {
 
 //////////////////////////////////////////////////////////////////////////
 
-void LifeFormAppearance::SetEntityEntityCompliance(EntityCompliance EC) {
+void LifeFormAppearance::SetEntityCompliance(EntityCompliance EC) {
   m_Compliance = EC;
 }
 
 //////////////////////////////////////////////////////////////////////////
 
-EntityCompliance LifeFormAppearance::GetEntityEntityCompliance() const {
+EntityCompliance LifeFormAppearance::GetEntityCompliance() const {
   return (EntityCompliance)m_Compliance;
 }
 

--- a/tests/DataType_EncodeDecode5.cpp
+++ b/tests/DataType_EncodeDecode5.cpp
@@ -19,6 +19,7 @@
 #include <KDIS/DataTypes/EulerAngles.hpp>
 #include <KDIS/DataTypes/FixedDatum.hpp>
 #include <KDIS/DataTypes/FundamentalParameterData.hpp>
+#include <KDIS/DataTypes/LifeFormAppearance.hpp>
 #include <KDIS/DataTypes/ModulationType.hpp>
 #include <KDIS/DataTypes/MunitionDescriptor.hpp>
 #include <KDIS/DataTypes/RadioEntityType.hpp>
@@ -174,6 +175,15 @@ TEST(DataType_EncodeDecode5, FundamentalParameterData) {
   KDIS::DATA_TYPE::FundamentalParameterData dtOut(stream);
   EXPECT_EQ(dtIn, dtOut);
   EXPECT_EQ(0, stream.GetBufferSize());
+}
+
+TEST(DataType_EncodeDecode5, LifeFormAppearance) {
+  KDIS::DATA_TYPE::LifeFormAppearance dtIn;
+  constexpr KDIS::DATA_TYPE::ENUMS::EntityCompliance ec{
+      KDIS::DATA_TYPE::ENUMS::Detained};
+  EXPECT_NO_THROW(dtIn.SetEntityCompliance(ec));
+  EXPECT_EQ(ec, dtIn.GetEntityCompliance());
+  // LifeFormAppearance has no Encode/Decode feature
 }
 
 TEST(DataType_EncodeDecode5, ModulationType) {


### PR DESCRIPTION
Also added unit testing to support this change, and confirmed that no other method in KDIS used this "EntityEntity" naming.