### PR TITLE
fix: member assignment in LinearObjectAppearance::SetBreachLocation()…

### DIFF
--- a/src/DataTypes/LinearObjectAppearance.cpp
+++ b/src/DataTypes/LinearObjectAppearance.cpp
@@ -28,7 +28,6 @@ http://p.sf.net/kdis/UserGuide
 *********************************************************************/
 
 #include "KDIS/DataTypes/LinearObjectAppearance.hpp"
-
 #include "KDIS/util/format.hpp"
 
 using namespace KDIS;
@@ -83,7 +82,7 @@ KUINT8 LinearObjectAppearance::GetBreachLength() const {
 
 void LinearObjectAppearance::SetBreachLocation(const bitset<8>& L) {
   KUINT32 i = L.to_ulong();
-  m_SpecificAppearanceUnion.m_TankDitchConcertinaWire.m_ui32BreachLength =
+  m_SpecificAppearanceUnion.m_TankDitchConcertinaWire.m_ui32BreachLoc =
       (KUINT8)i;
 }
 
@@ -102,9 +101,8 @@ KUINT8 LinearObjectAppearance::GetBreachLocation() const {
 ////////////////////////////////////////////////////////////////////////////
 
 bitset<8> LinearObjectAppearance::GetBreachLocationAsBitset() {
-  return bitset<8>((KINT32)m_SpecificAppearanceUnion.m_TankDitchConcertinaWire
-                       .m_ui32BreachLoc);  // We need to cast to a signed int,
-                                           // this is a visual studio 2010 fix
+  return bitset<8>(
+      m_SpecificAppearanceUnion.m_TankDitchConcertinaWire.m_ui32BreachLoc);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/tests/DataType_EncodeDecode5.cpp
+++ b/tests/DataType_EncodeDecode5.cpp
@@ -19,6 +19,7 @@
 #include <KDIS/DataTypes/EulerAngles.hpp>
 #include <KDIS/DataTypes/FixedDatum.hpp>
 #include <KDIS/DataTypes/FundamentalParameterData.hpp>
+#include <KDIS/DataTypes/LinearObjectAppearance.hpp>
 #include <KDIS/DataTypes/ModulationType.hpp>
 #include <KDIS/DataTypes/MunitionDescriptor.hpp>
 #include <KDIS/DataTypes/RadioEntityType.hpp>
@@ -30,6 +31,7 @@
 #include <KDIS/DataTypes/VariableParameter.hpp>
 #include <KDIS/DataTypes/Vector.hpp>
 #include <KDIS/DataTypes/WorldCoordinates.hpp>
+#include <bitset>
 #include <iostream>
 
 TEST(DataType_EncodeDecode5, AntennaLocation) {
@@ -172,6 +174,17 @@ TEST(DataType_EncodeDecode5, FundamentalParameterData) {
   KDIS::DATA_TYPE::FundamentalParameterData dtIn;
   KDIS::KDataStream stream = dtIn.Encode();
   KDIS::DATA_TYPE::FundamentalParameterData dtOut(stream);
+  EXPECT_EQ(dtIn, dtOut);
+  EXPECT_EQ(0, stream.GetBufferSize());
+}
+
+TEST(DataType_EncodeDecode5, LinearObjectAppearance) {
+  KDIS::DATA_TYPE::LinearObjectAppearance dtIn;
+  constexpr std::bitset<8> bs{0x4F};
+  EXPECT_NO_THROW(dtIn.SetBreachLocation(bs));
+  EXPECT_EQ(bs, dtIn.GetBreachLocationAsBitset());
+  KDIS::KDataStream stream = dtIn.Encode();
+  KDIS::DATA_TYPE::LinearObjectAppearance dtOut(stream);
   EXPECT_EQ(dtIn, dtOut);
   EXPECT_EQ(0, stream.GetBufferSize());
 }

--- a/tests/DataType_EncodeDecode5.cpp
+++ b/tests/DataType_EncodeDecode5.cpp
@@ -20,7 +20,6 @@
 #include <KDIS/DataTypes/FixedDatum.hpp>
 #include <KDIS/DataTypes/FundamentalParameterData.hpp>
 #include <KDIS/DataTypes/LifeFormAppearance.hpp>
-#include <KDIS/DataTypes/LinearObjectAppearance.hpp>
 #include <KDIS/DataTypes/ModulationType.hpp>
 #include <KDIS/DataTypes/MunitionDescriptor.hpp>
 #include <KDIS/DataTypes/RadioEntityType.hpp>
@@ -186,17 +185,6 @@ TEST(DataType_EncodeDecode5, LifeFormAppearance) {
   EXPECT_NO_THROW(dtIn.SetEntityCompliance(ec));
   EXPECT_EQ(ec, dtIn.GetEntityCompliance());
   // LifeFormAppearance has no Encode/Decode feature
-}
-
-TEST(DataType_EncodeDecode5, LinearObjectAppearance) {
-  KDIS::DATA_TYPE::LinearObjectAppearance dtIn;
-  constexpr std::bitset<8> bs{0x4F};
-  EXPECT_NO_THROW(dtIn.SetBreachLocation(bs));
-  EXPECT_EQ(bs, dtIn.GetBreachLocationAsBitset());
-  KDIS::KDataStream stream = dtIn.Encode();
-  KDIS::DATA_TYPE::LinearObjectAppearance dtOut(stream);
-  EXPECT_EQ(dtIn, dtOut);
-  EXPECT_EQ(0, stream.GetBufferSize());
 }
 
 TEST(DataType_EncodeDecode5, ModulationType) {

--- a/tests/DataType_EncodeDecode6.cpp
+++ b/tests/DataType_EncodeDecode6.cpp
@@ -441,6 +441,9 @@ TEST(DataType_EncodeDecode6, LE_EulerAngles) {
 
 TEST(DataType_EncodeDecode6, LinearObjectAppearance) {
   KDIS::DATA_TYPE::LinearObjectAppearance dtIn;
+  constexpr std::bitset<8> bs{0x4F};
+  EXPECT_NO_THROW(dtIn.SetBreachLocation(bs));
+  EXPECT_EQ(bs, dtIn.GetBreachLocationAsBitset());
   KDIS::KDataStream stream = dtIn.Encode();
   KDIS::DATA_TYPE::LinearObjectAppearance dtOut(stream);
   EXPECT_EQ(dtIn, dtOut);


### PR DESCRIPTION
Also remove `KINT32` cast whose commented reason didn't justify converting from `KUINT32` to `KINT32`, and which wasn't supported by a unit test for the named platform. Add unit tests supporting this overall change.