### PR TITLE
fix: Incomplete copy constructor in Simulation_Management_Header #78

### DIFF
--- a/src/PDU/Simulation_Management/Simulation_Management_Header.cpp
+++ b/src/PDU/Simulation_Management/Simulation_Management_Header.cpp
@@ -58,7 +58,9 @@ Simulation_Management_Header::Simulation_Management_Header() {
 
 Simulation_Management_Header::Simulation_Management_Header(
     const Simulation_Management_Header& H)
-    : Header(H) {}
+    : Header(H),
+      m_OriginatingEntityID(H.GetOriginatingEntityID()),
+      m_ReceivingEntityID(H.GetReceivingEntityID()) {}
 
 //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
One of the copy constructors in Simulation_Management_Header does not copy the entity ID members.